### PR TITLE
Attempt to thread error throughout

### DIFF
--- a/dataloader-lwt/src/dataloader_lwt.ml
+++ b/dataloader-lwt/src/dataloader_lwt.ml
@@ -1,5 +1,5 @@
-type ('a, 'b) t = {
-  dataloader : ('a, 'b) Dataloader.t;
+type ('a, 'b, 'err) t = {
+  dataloader : ('a, 'b, 'err) Dataloader.t;
   mutable pause : unit Lwt.t option;
 }
 
@@ -20,7 +20,7 @@ let pause t =
       Dataloader.trigger t.dataloader
     in
     t.pause <- Some pause;
-    pause 
+    pause
   | Some pause -> pause
 
 let load t key =

--- a/dataloader-lwt/src/dataloader_lwt.mli
+++ b/dataloader-lwt/src/dataloader_lwt.mli
@@ -1,10 +1,10 @@
-type ('a, 'b) t
+type ('a, 'b, 'err) t
 
 val create :
-  load:('a list -> ('b list, exn) result Lwt.t) ->
-  ('a, 'b) t
+  load:('a list -> ('b list, 'err) result Lwt.t) ->
+  ('a, 'b, 'err) t
 
 val load :
-  ('a, 'b) t ->
+  ('a, 'b, 'err) t ->
   'a ->
-  ('b, exn) result Lwt.t
+  ('b, 'err) result Lwt.t

--- a/dataloader/src/dataloader.ml
+++ b/dataloader/src/dataloader.ml
@@ -1,16 +1,16 @@
 type 'a cont = 'a -> unit
-type 'a cps = exn cont -> 'a cont -> unit
-type ('key, 'value) loader = 'key list -> 'value list cps
+type ('a, 'err) cps = 'err cont -> 'a cont -> unit
+type ('key, 'value, 'err) loader = 'key list -> ('value list, 'err) cps
 
-type ('key, 'value) entry = {
+type ('key, 'value, 'err) entry = {
   key  : 'key;
-  fail : exn cont;
+  fail : 'err cont;
   ok   : 'value cont;
 }
 
-type ('key, 'value) t = {
-  loader : ('key, 'value) loader;
-  mutable entries : ('key, 'value) entry list
+type ('key, 'value, 'err) t = {
+  loader : ('key, 'value, 'err) loader;
+  mutable entries : ('key, 'value, 'err) entry list
 }
 
 let create ~load =

--- a/dataloader/src/dataloader.mli
+++ b/dataloader/src/dataloader.mli
@@ -1,18 +1,18 @@
-type ('a, 'b) t
+type ('a, 'b, 'err) t
 
 type 'a cont = 'a -> unit
-type 'a cps = exn cont -> 'a cont -> unit
-type ('a, 'b) loader = 'a list -> 'b list cps
+type ('a, 'err) cps = 'err cont -> 'a cont -> unit
+type ('a, 'b, 'err) loader = 'a list -> ('b list, 'err) cps
 
 val create :
-  load:('a, 'b) loader ->
-  ('a, 'b) t
+  load:('a, 'b, 'err) loader ->
+  ('a, 'b, 'err) t
 
 val load :
-  ('a, 'b) t ->
+  ('a, 'b, 'err) t ->
   'a ->
-  'b cps
+  ('b, 'err) cps
 
 val trigger :
-  ('a, 'b) t ->
+  ('a, 'b, 'err) t ->
   unit


### PR DESCRIPTION
I was trying to use this library with `caqti` and the error types didn't line up so I had to do a lot of converting back-and-forth.  Would it make sense to thread the generic error type throughout the types?